### PR TITLE
Skip tests and examples when torch is not installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     testthat (>= 3.0.0),
     knitr,
     rmarkdown
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3
 BugReports: https://github.com/ielbadisy/survdnn/issues
 URL: https://github.com/ielbadisy/survdnn

--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -13,6 +13,7 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran)
 #' \donttest{
@@ -20,6 +21,7 @@
 #'                data = veteran, epochs = 5, verbose = FALSE)
 #' evaluate_survdnn(mod, metrics = c("cindex", "ibs"), times = c(30, 90, 180))
 #' evaluate_survdnn(mod, metrics = "brier", times = c(30, 90, 180))
+#' }
 #' }
 evaluate_survdnn <- function(model, metrics = c("cindex", "brier", "ibs"), times, newdata = NULL) {
   stopifnot(inherits(model, "survdnn"))
@@ -73,6 +75,7 @@ evaluate_survdnn <- function(model, metrics = c("cindex", "brier", "ibs"), times
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran)
 #' cv_survdnn(
@@ -85,6 +88,7 @@ evaluate_survdnn <- function(model, metrics = c("cindex", "brier", "ibs"), times
 #'   hidden = c(16, 8),
 #'   epochs = 5
 #' )
+#' }
 cv_survdnn <- function(formula, data, times,
                        metrics = c("cindex", "ibs"),
                        folds = 5,
@@ -127,6 +131,7 @@ cv_survdnn <- function(formula, data, times,
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran)
 #' res <- cv_survdnn(
@@ -140,6 +145,7 @@ cv_survdnn <- function(formula, data, times,
 #'   epochs = 5
 #' )
 #' summarize_cv_survdnn(res)
+#' }
 summarize_cv_survdnn <- function(cv_results, by_time = TRUE, conf_level = 0.95) {
   stopifnot(all(c("fold", "metric", "value") %in% names(cv_results)))
 

--- a/R/gridsearch_survdnn.R
+++ b/R/gridsearch_survdnn.R
@@ -14,23 +14,21 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' \donttest{
 #' library(survdnn)
 #' library(survival)
 #' set.seed(123)
-#'
 #' # Simulate small dataset
 #' n <- 300
 #' x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
 #' time <- rexp(n, rate = 0.1)
 #' status <- rbinom(n, 1, 0.7)
 #' df <- data.frame(time, status, x1, x2)
-#'
 #' # Split into training and validation
 #' idx <- sample(seq_len(n), 0.7 * n)
 #' train <- df[idx, ]
 #' valid <- df[-idx, ]
-#'
 #' # Define formula and param grid
 #' formula <- Surv(time, status) ~ x1 + x2
 #' param_grid <- list(
@@ -40,7 +38,6 @@
 #'   epochs     = c(100),
 #'   loss       = c("cox", "coxtime")
 #' )
-#'
 #' # Run grid search
 #' results <- gridsearch_survdnn(
 #'   formula = formula,
@@ -50,10 +47,10 @@
 #'   metrics = c("cindex", "ibs"),
 #'   param_grid = param_grid
 #' )
-#'
 #' # View summary
 #' dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
 #'   dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+#' }
 #' }
 gridsearch_survdnn <- function(formula, train, valid, times,
                                metrics = c("cindex", "ibs"),

--- a/R/losses.R
+++ b/R/losses.R
@@ -107,4 +107,3 @@ coxtime_loss <- function(pred, true) {
   loss <- torch_mean(loss_terms)
   return(loss)
 }
-

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -13,6 +13,7 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran, package = "survival")
 #' mod <- survdnn(Surv(time, status) ~
@@ -20,6 +21,7 @@
 #' pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
 #' y <- model.response(model.frame(mod$formula, veteran))
 #' cindex_survmat(y, pred, t_star = 180)
+#' }
 
 cindex_survmat <- function(object, predicted, t_star = NULL) {
   if (!inherits(object, "Surv")) stop("object must be a survival object (from Surv())")
@@ -89,6 +91,7 @@ cindex_survmat <- function(object, predicted, t_star = NULL) {
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran, package = "survival")
 #' mod <- survdnn(Surv(time, status) ~
@@ -96,6 +99,7 @@ cindex_survmat <- function(object, predicted, t_star = NULL) {
 #' pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
 #' y <- model.response(model.frame(mod$formula, veteran))
 #' survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+#' }
 
 brier <- function(object, pre_sp, t_star) {
   if (!inherits(object, "Surv")) stop("object must be a survival object")
@@ -152,6 +156,7 @@ brier <- function(object, pre_sp, t_star) {
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' set.seed(123)
 #' library(survival)
 #' data(veteran, package = "survival")
@@ -162,6 +167,7 @@ brier <- function(object, pre_sp, t_star) {
 #' pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
 #' y_test <- model.response(model.frame(mod$formula, test))
 #' ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+#' }
 
 ibs_survmat <- function(object, sp_matrix, times) {
   if (!inherits(object, "Surv")) stop("object must be a survival object")

--- a/R/plot.survdnn.R
+++ b/R/plot.survdnn.R
@@ -19,6 +19,7 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran)
 #' set.seed(42)
@@ -26,6 +27,7 @@
 #' mod <- survdnn(Surv(time, status) ~ age + karno + celltype, data = veteran,
 #'                hidden = c(16, 8), epochs = 100, verbose = FALSE)
 #' plot(mod, group_by = "celltype", times = 1:300)
+#' }
 #' }
 plot.survdnn <- function(x, newdata = NULL, times = 1:365,
                          group_by = NULL,

--- a/R/predict.survdnn.R
+++ b/R/predict.survdnn.R
@@ -21,6 +21,7 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran, package = "survival")
 #'
@@ -36,6 +37,7 @@
 #'
 #' # Cumulative risk at 180 days
 #' predict(mod, newdata = veteran, type = "risk", times = 180)[1:5]
+#' }
 
 predict.survdnn <- function(object, newdata, times = NULL,
                             type = c("survival", "lp", "risk"), ...) {

--- a/R/print.survdnn.R
+++ b/R/print.survdnn.R
@@ -10,11 +10,13 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' library(survival)
 #' data(veteran, package = "survival")
 #' mod <- survdnn(Surv(time, status) ~
 #' age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
 #' print(mod)
+#' }
 print.survdnn <- function(x, ...) {
   stopifnot(inherits(x, "survdnn"))
 

--- a/R/summary.survdnn.R
+++ b/R/summary.survdnn.R
@@ -11,6 +11,7 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' set.seed(42)
 #' sim_data <- data.frame(
 #'   age = rnorm(100, 60, 10),
@@ -21,6 +22,7 @@
 #' )
 #' mod <- survdnn(Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
 #' summary(mod)
+#' }
 summary.survdnn <- function(object, ...) {
   stopifnot(inherits(object, "survdnn"))
 

--- a/R/survdnn.R
+++ b/R/survdnn.R
@@ -15,7 +15,9 @@
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' net <- build_dnn(10, hidden = c(64, 32), activation = "relu")
+#' }
 build_dnn <- function(input_dim, hidden, activation = "relu", output_dim = 1L) {
   layers <- list()
   in_features <- input_dim
@@ -81,6 +83,7 @@ build_dnn <- function(input_dim, hidden, activation = "relu", output_dim = 1L) {
 #' @export
 #'
 #' @examples
+#' if (torch::torch_is_installed()) {
 #' set.seed(123)
 #' df <- data.frame(
 #'   time = rexp(100, rate = 0.1),
@@ -92,6 +95,7 @@ build_dnn <- function(input_dim, hidden, activation = "relu", output_dim = 1L) {
 #' 
 #' , loss = "cox", verbose = FALSE)
 #' mod$final_loss
+#' }
 survdnn <- function(formula, data,
                     hidden = c(32L, 16L),
                     activation = "relu",

--- a/man/brier.Rd
+++ b/man/brier.Rd
@@ -20,6 +20,7 @@ A single numeric value representing the Brier score.
 Computes the Brier score at a fixed time point using inverse probability of censoring weights (IPCW).
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran, package = "survival")
 mod <- survdnn(Surv(time, status) ~
@@ -27,4 +28,5 @@ age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
 pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
 y <- model.response(model.frame(mod$formula, veteran))
 survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+}
 }

--- a/man/build_dnn.Rd
+++ b/man/build_dnn.Rd
@@ -25,6 +25,8 @@ activation functions, and dropout. Used internally by [survdnn()] to
 define the model architecture.
 }
 \examples{
+if (torch::torch_is_installed()) {
 net <- build_dnn(10, hidden = c(64, 32), activation = "relu")
+}
 }
 \keyword{internal}

--- a/man/cindex_survmat.Rd
+++ b/man/cindex_survmat.Rd
@@ -23,6 +23,7 @@ Computes the time-dependent concordance index (C-index) from a predicted surviva
 at a fixed time point. The risk is computed as `1 - S(t_star)`.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran, package = "survival")
 mod <- survdnn(Surv(time, status) ~
@@ -30,4 +31,5 @@ age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
 pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
 y <- model.response(model.frame(mod$formula, veteran))
 cindex_survmat(y, pred, t_star = 180)
+}
 }

--- a/man/cv_survdnn.Rd
+++ b/man/cv_survdnn.Rd
@@ -36,6 +36,7 @@ A tibble containing metric values per fold and (optionally) per time point.
 Performs cross-validation for a `survdnn` model using the specified evaluation metrics.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran)
 cv_survdnn(
@@ -48,4 +49,5 @@ cv_survdnn(
   hidden = c(16, 8),
   epochs = 5
 )
+}
 }

--- a/man/evaluate_survdnn.Rd
+++ b/man/evaluate_survdnn.Rd
@@ -29,6 +29,7 @@ Supported metrics include the concordance index (`"cindex"`), Brier score (`"bri
 and integrated Brier score (`"ibs"`).
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran)
 \donttest{
@@ -36,5 +37,6 @@ mod <- survdnn(Surv(time, status) ~ age + karno + celltype,
                data = veteran, epochs = 5, verbose = FALSE)
 evaluate_survdnn(mod, metrics = c("cindex", "ibs"), times = c(30, 90, 180))
 evaluate_survdnn(mod, metrics = "brier", times = c(30, 90, 180))
+}
 }
 }

--- a/man/gridsearch_survdnn.Rd
+++ b/man/gridsearch_survdnn.Rd
@@ -36,23 +36,21 @@ A tibble with configurations and their validation metrics
 Performs grid search over user-specified hyperparameters and evaluates performance on a validation set.
 }
 \examples{
+if (torch::torch_is_installed()) {
 \donttest{
 library(survdnn)
 library(survival)
 set.seed(123)
-
 # Simulate small dataset
 n <- 300
 x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
 time <- rexp(n, rate = 0.1)
 status <- rbinom(n, 1, 0.7)
 df <- data.frame(time, status, x1, x2)
-
 # Split into training and validation
 idx <- sample(seq_len(n), 0.7 * n)
 train <- df[idx, ]
 valid <- df[-idx, ]
-
 # Define formula and param grid
 formula <- Surv(time, status) ~ x1 + x2
 param_grid <- list(
@@ -62,7 +60,6 @@ param_grid <- list(
   epochs     = c(100),
   loss       = c("cox", "coxtime")
 )
-
 # Run grid search
 results <- gridsearch_survdnn(
   formula = formula,
@@ -72,9 +69,9 @@ results <- gridsearch_survdnn(
   metrics = c("cindex", "ibs"),
   param_grid = param_grid
 )
-
 # View summary
 dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
   dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+}
 }
 }

--- a/man/ibs_survmat.Rd
+++ b/man/ibs_survmat.Rd
@@ -22,6 +22,7 @@ Computes the Integrated Brier Score (IBS) over a set of evaluation time points,
 using trapezoidal integration and IPCW adjustment for right-censoring.
 }
 \examples{
+if (torch::torch_is_installed()) {
 set.seed(123)
 library(survival)
 data(veteran, package = "survival")
@@ -32,4 +33,5 @@ age + karno + celltype, data = train, epochs = 50, verbose = FALSE)
 pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
 y_test <- model.response(model.frame(mod$formula, test))
 ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+}
 }

--- a/man/plot.survdnn.Rd
+++ b/man/plot.survdnn.Rd
@@ -47,6 +47,7 @@ Curves can be grouped by a categorical variable in `newdata` and
 optionally display only the group-wise means or overlay them.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran)
 set.seed(42)
@@ -54,5 +55,6 @@ set.seed(42)
 mod <- survdnn(Surv(time, status) ~ age + karno + celltype, data = veteran,
                hidden = c(16, 8), epochs = 100, verbose = FALSE)
 plot(mod, group_by = "celltype", times = 1:300)
+}
 }
 }

--- a/man/predict.survdnn.Rd
+++ b/man/predict.survdnn.Rd
@@ -32,6 +32,7 @@ Generate predictions from a fitted `survdnn` model for new data. Supports linear
 survival probabilities at specified time points, or cumulative risk estimates.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran, package = "survival")
 
@@ -47,4 +48,5 @@ predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))[1:5, 
 
 # Cumulative risk at 180 days
 predict(mod, newdata = veteran, type = "risk", times = 180)[1:5]
+}
 }

--- a/man/print.survdnn.Rd
+++ b/man/print.survdnn.Rd
@@ -19,9 +19,11 @@ Pretty prints a fitted `survdnn` model. Displays the formula,
 network architecture, training configuration, and final training loss.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran, package = "survival")
 mod <- survdnn(Surv(time, status) ~
 age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
 print(mod)
+}
 }

--- a/man/summarize_cv_survdnn.Rd
+++ b/man/summarize_cv_survdnn.Rd
@@ -20,6 +20,7 @@ A tibble summarizing mean, sd, and confidence bounds per metric (and per time if
 Computes mean, standard deviation, and confidence intervals for metrics from cross-validation.
 }
 \examples{
+if (torch::torch_is_installed()) {
 library(survival)
 data(veteran)
 res <- cv_survdnn(
@@ -33,4 +34,5 @@ res <- cv_survdnn(
   epochs = 5
 )
 summarize_cv_survdnn(res)
+}
 }

--- a/man/summary.survdnn.Rd
+++ b/man/summary.survdnn.Rd
@@ -20,6 +20,7 @@ training configuration, and data characteristics. The summary is printed automat
 a styled header and sectioned output using \{cli\} and base formatting. The object is returned invisibly.
 }
 \examples{
+if (torch::torch_is_installed()) {
 set.seed(42)
 sim_data <- data.frame(
   age = rnorm(100, 60, 10),
@@ -30,4 +31,5 @@ sim_data <- data.frame(
 )
 mod <- survdnn(Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
 summary(mod)
+}
 }

--- a/man/survdnn.Rd
+++ b/man/survdnn.Rd
@@ -56,6 +56,7 @@ Trains a deep neural network (DNN) to model right-censored survival data
 using one of the predefined loss functions: Cox, AFT, or Coxtime.
 }
 \examples{
+if (torch::torch_is_installed()) {
 set.seed(123)
 df <- data.frame(
   time = rexp(100, rate = 0.1),
@@ -67,4 +68,5 @@ mod <- survdnn(Surv(time, status) ~ x1 + x2, data = df, epochs = 5
 
 , loss = "cox", verbose = FALSE)
 mod$final_loss
+}
 }

--- a/tests/testthat/test-losses.R
+++ b/tests/testthat/test-losses.R
@@ -2,6 +2,8 @@ library(testthat)
 library(torch)
 
 test_that("cox_loss returns scalar tensor", {
+  skip_if_not(torch_is_installed())
+
   time <- torch_tensor(runif(20, 1, 100))
   status <- torch_tensor(sample(0:1, 20, replace = TRUE))
   y <- torch_stack(list(time, status), dim = 2)
@@ -13,6 +15,8 @@ test_that("cox_loss returns scalar tensor", {
 })
 
 test_that("cox_l2_loss returns penalized scalar tensor", {
+  skip_if_not(torch_is_installed())
+
   time <- torch_tensor(runif(20, 1, 100))
   status <- torch_tensor(sample(0:1, 20, replace = TRUE))
   y <- torch_stack(list(time, status), dim = 2)
@@ -26,6 +30,8 @@ test_that("cox_l2_loss returns penalized scalar tensor", {
 
 
 test_that("aft_loss returns scalar tensor (uncensored only)", {
+  skip_if_not(torch_is_installed())
+
   time <- torch_tensor(runif(20, 1, 100))
   status <- torch_tensor(sample(0:1, 20, replace = TRUE))
   y <- torch_stack(list(time, status), dim = 2)
@@ -37,6 +43,8 @@ test_that("aft_loss returns scalar tensor (uncensored only)", {
 })
 
 test_that("aft_loss returns 0 for fully censored data", {
+  skip_if_not(torch_is_installed())
+
   time <- torch_tensor(runif(10, 1, 100))
   status <- torch_tensor(torch_zeros(10))
   y <- torch_stack(list(time, status), dim = 2)
@@ -50,7 +58,7 @@ test_that("aft_loss returns 0 for fully censored data", {
 
 
 test_that("coxtime_loss implements partial likelihood faithfully", {
-  skip_if_not(torch::torch_is_installed())
+  skip_if_not(torch_is_installed())
 
   n <- 50
   pred <- torch_randn(c(n, 1))


### PR DESCRIPTION
CRAN has sometimes a version of LibTorch installed, but it may not be installed in some runners. 

So we should guard the tests and examples to check if torch is installed, before executing, otherwise we get errors like:

```
> data(veteran, package = "survival")
  Warning in data(veteran, package = "survival") :
    data set ‘veteran’ not found
  > mod <- survdnn(Surv(time, status) ~
  + age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
  Error in cpp_torch_float32() :
    Lantern is not loaded. Please use `install_torch()` to install additional dependencies.
  Calls: survdnn ... <Anonymous> -> <Anonymous> -> <Anonymous> -> cpp_torch_float32
  Execution halted
```

This PR fixes reverse dependencies errors found when submitting torch v0.16.1 to CRAN. 