### PR TITLE
CRAN: remove auto-install of torch on load; bump to 0.6.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: survdnn
 Title: Deep Neural Networks for Survival Analysis Using 'torch'
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: 
     person(given = "Imad", 
            family = "EL BADISY", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,49 @@
+## survdnn 0.6.2
+
+### Maintenance release (CRAN compliance)
+
+- **Removed automatic `torch::install_torch()` on load:**  
+  The package no longer downloads or installs Torch libraries automatically when loaded.  
+  The `.onLoad()` function now performs only a silent availability check, and `.onAttach()`  
+  displays an informative message instructing users to manually run  
+  `torch::install_torch()` when necessary.  
+  This update ensures full compliance with CRAN policies that forbid modification of user environments  
+  or network activity during package load.
+
+- Updated startup message for clearer user guidance.
+- Internal documentation and version bump for CRAN resubmission.
+
+---
+
+## survdnn 0.6.1
+
+### Infrastructure and testing improvements
+
+- Added conditional test skipping: tests and examples now use  
+  `skip_if_not(torch_is_installed())` and `skip_on_cran()` to avoid failures  
+  on systems where Torch is not available.  
+  (Thanks to @dfalbel for the PR.)
+
+- Regenerated documentation (`RoxygenNote: 7.3.3`) and updated man pages.
+- Minor internal consistency fixes and CI checks update.
+
+---
+
 ## survdnn 0.6.0
 
-First public release of `survdnn` (Deep Neural Networks for Survival Analysis in R using `torch`).
+First public release of `survdnn` — Deep Neural Networks for Survival Analysis in R using `torch`.
 
 ### Features
 
-- `survdnn()`: Fit deep learning survival models using a formula interface
-- Supported loss functions: Cox partial likelihood (`"cox"`), L2-penalized Cox (`"cox_l2"`); Time-dependent Cox (`"coxtime"`), and Accelerated Failure Time (`"aft"`)
-- Cross-validation with `cv_survdnn()`
-- Hyperparameter tuning with `tune_survdnn()`
-- Survival probability prediction and curve plotting
-- Evaluation metrics: C-index, Brier score, Integrated Brier Score (IBS)
+- `survdnn()`: Fit deep learning survival models using a formula interface.
+- Supported loss functions:  
+  - Cox partial likelihood (`"cox"`)  
+  - L2-penalized Cox (`"cox_l2"`)  
+  - Time-dependent Cox (`"coxtime"`)  
+  - Accelerated Failure Time (`"aft"`)
+- Cross-validation with `cv_survdnn()`.
+- Hyperparameter tuning with `tune_survdnn()`.
+- Survival probability prediction and curve plotting.
+- Evaluation metrics: Concordance index (C-index), Brier score, and Integrated Brier Score (IBS).
 
-CRAN submission prepared. README, documentation, and tests included.
+CRAN submission prepared. Includes README, documentation, and automated tests.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,10 +10,9 @@
     "n", "se", "hidden", "lr", "activation", "epochs", "loss_name", ".loss_fn"
   ))
 
-  if (requireNamespace("torch", quietly = TRUE)) {
-    if (!torch::torch_is_installed()) {
-      try(torch::install_torch(), silent = TRUE)
-    }
+  # CRAN policy: do not auto-install or download anything on load.
+  # only perform a harmless check if torch is both available and installed!
+  if (requireNamespace("torch", quietly = TRUE) && torch::torch_is_installed()) {
     try(torch::torch_tensor(0), silent = TRUE)
   }
 }
@@ -25,8 +24,8 @@
   if (!torch::torch_is_installed() && interactive()) {
     msg <- paste0(
       cli::rule("Torch Backend Not Installed", line_col = "red"),
-      "\nTorch will be automatically installed when needed.",
-      "\nIf installation fails, you can run manually: ", cli::col_yellow("install_torch()"),
+      "\nThis package requires torch for deep learning operations.",
+      "\nInstall manually with: ", cli::col_yellow("torch::install_torch()"),
       "\nDocs: https://torch.mlverse.org/docs/articles/installation.html"
     )
     packageStartupMessage(msg)


### PR DESCRIPTION
This PR addresses CRAN feedback regarding automatic installation of the `torch` backend on package load.

- Removed `torch::install_torch()` from `.onLoad()` to comply with CRAN policy (no automatic downloads).
- Retained a simple availability check with an informative startup message.
- Updated `DESCRIPTION`, `NEWS.md`, and version to 0.6.2.
- Verified with `rcmdcheck::rcmdcheck(args = "--as-cran")`, all is good!