### PR TITLE
feat: implement global reproducibility handling (R + torch)

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -102,11 +102,14 @@ cv_survdnn <- function(formula, data, times,
   if (!is.data.frame(data)) stop("`data` must be a data frame")
   if (missing(times)) stop("You must provide a `times` vector.")
 
-  if (!is.null(.seed)) set.seed(.seed)
+  if (!is.null(.seed)) survdnn_set_seed(.seed)
 
   vfolds <- rsample::vfold_cv(data, v = folds, strata = all.vars(formula)[1])
 
   results <- purrr::imap_dfr(vfolds$splits, function(split, i) {
+    
+    ## re-seed inside every fold to ensure full reproducibility
+    survdnn_set_seed(.seed)
     train_data <- rsample::analysis(split)
     test_data  <- rsample::assessment(split)
     model <- survdnn(formula, data = train_data, ...)

--- a/R/survdnn.R
+++ b/R/survdnn.R
@@ -62,7 +62,8 @@ build_dnn <- function(input_dim, hidden, activation = "relu", output_dim = 1L) {
 #' @param epochs Number of training epochs (default: 300).
 #' @param loss Character name of the loss function to use. One of `"cox"`, `"cox_l2"`, `"aft"`, or `"coxtime"`.
 #' @param verbose Logical; whether to print loss progress every 50 epochs (default: TRUE).
-#'
+#' @param .seed Optional integer. If provided, sets both R and torch random seeds for reproducible weight initialization, shuffling, and dropout.
+
 #' @return An object of class `"survdnn"` containing:
 #' \describe{
 #'   \item{model}{Trained `nn_module` object.}
@@ -102,7 +103,11 @@ survdnn <- function(formula, data,
                     lr = 1e-4,
                     epochs = 300L,
                     loss = c("cox", "cox_l2", "aft", "coxtime"),
-                    verbose = TRUE) {
+                    verbose = TRUE,
+                    .seed = NULL
+                  ) {
+
+  survdnn_set_seed(.seed)
   stopifnot(inherits(formula, "formula"))
   stopifnot(is.data.frame(data))
 

--- a/R/tune_survdnn.R
+++ b/R/tune_survdnn.R
@@ -13,7 +13,7 @@ utils::globalVariables(c("loss"))
 #' @param param_grid A named list defining hyperparameter combinations to evaluate.
 #'                   Required names: `hidden`, `lr`, `activation`, `epochs`, `loss`.
 #' @param folds Number of cross-validation folds (default: 3).
-#' @param .seed Optional seed for reproducibility (default: 42).
+#' @param .seed Optional seed for reproducibility.
 #' @param refit Logical. If TRUE, refits the best model on the full dataset.
 #' @param return One of "all", "summary", or "best_model":
 #'   \describe{
@@ -24,12 +24,18 @@ utils::globalVariables(c("loss"))
 #'
 #' @return A tibble or model object depending on the `return` value.
 #' @export
-tune_survdnn <- function(formula, data, times, metrics = "cindex",
-                         param_grid, folds = 3, .seed = 42,
+tune_survdnn <- function(formula, 
+                         data, 
+                         times, 
+                         metrics = "cindex",
+                         param_grid, 
+                         folds = 3, 
+                         .seed = 42,
                          refit = FALSE,
                          return = c("all", "summary", "best_model")) {
   return <- match.arg(return)
-  if (!is.null(.seed)) set.seed(.seed)
+  
+  if (!is.null(.seed)) survdnn_set_seed(.seed)
 
   param_df <- tidyr::crossing(!!!param_grid)
 
@@ -52,7 +58,8 @@ tune_survdnn <- function(formula, data, times, metrics = "cindex",
       lr = lr,
       activation = activation,
       epochs = epochs,
-      loss = loss
+      loss = loss,
+      .seed = .seed
     )
 
     dplyr::bind_cols(config_tbl[rep(1, nrow(cv_tbl)), ], cv_tbl)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,3 +29,21 @@
   }
   invisible()
 }
+
+
+## set R + torch seeds safely
+survdnn_set_seed <- function(.seed = NULL) {
+  if (is.null(.seed)) return(invisible(NULL))
+
+  # R RNG
+  set.seed(.seed)
+
+  # torch RNG (only if available + backend installed)
+  if (requireNamespace("torch", quietly = TRUE)) {
+    if (isTRUE(torch::torch_is_installed())) {
+      torch::torch_manual_seed(.seed)
+    }
+  }
+
+  invisible(NULL)
+}

--- a/man/survdnn.Rd
+++ b/man/survdnn.Rd
@@ -12,7 +12,8 @@ survdnn(
   lr = 1e-04,
   epochs = 300L,
   loss = c("cox", "cox_l2", "aft", "coxtime"),
-  verbose = TRUE
+  verbose = TRUE,
+  .seed = NULL
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ Supported options: `"relu"`, `"leaky_relu"`, `"tanh"`, `"sigmoid"`, `"gelu"`, `"
 \item{loss}{Character name of the loss function to use. One of `"cox"`, `"cox_l2"`, `"aft"`, or `"coxtime"`.}
 
 \item{verbose}{Logical; whether to print loss progress every 50 epochs (default: TRUE).}
+
+\item{.seed}{Optional integer. If provided, sets both R and torch random seeds for reproducible weight initialization, shuffling, and dropout.}
 }
 \value{
 An object of class `"survdnn"` containing:

--- a/man/tune_survdnn.Rd
+++ b/man/tune_survdnn.Rd
@@ -31,7 +31,7 @@ Required names: `hidden`, `lr`, `activation`, `epochs`, `loss`.}
 
 \item{folds}{Number of cross-validation folds (default: 3).}
 
-\item{.seed}{Optional seed for reproducibility (default: 42).}
+\item{.seed}{Optional seed for reproducibility.}
 
 \item{refit}{Logical. If TRUE, refits the best model on the full dataset.}
 

--- a/tests/testthat/test-survdnn.R
+++ b/tests/testthat/test-survdnn.R
@@ -35,3 +35,44 @@ test_that("survdnn() fits a model and returns correct structure", {
     ignore.order = TRUE
   )
 })
+
+
+test_that("survdnn() is reproducible given .seed", {
+  skip_on_cran()
+  skip_if_not_installed("torch")
+  skip_if_not(torch::torch_is_installed())
+
+  set.seed(123)
+  n <- 80
+  df <- data.frame(
+    time   = rexp(n, rate = 0.1),
+    status = rbinom(n, 1, 0.7),
+    x1     = rnorm(n),
+    x2     = rbinom(n, 1, 0.5)
+  )
+
+  mod1 <- survdnn(
+    Surv(time, status) ~ x1 + x2,
+    data   = df,
+    hidden = c(8),
+    activation = "relu",
+    lr     = 1e-3,
+    epochs = 10,
+    loss   = "cox",
+    verbose = FALSE,
+    .seed   = 999
+  )
+
+  mod2 <- survdnn(
+    Surv(time, status) ~ x1 + x2,
+    data   = df,
+    hidden = c(8),
+    activation = "relu",
+    lr     = 1e-3,
+    epochs = 10,
+    loss   = "cox",
+    verbose = FALSE,
+    .seed   = 999
+  )
+  expect_equal(mod1$loss_history, mod2$loss_history)
+})


### PR DESCRIPTION
- Added .seed argument to `survdnn()`, `cv_survdnn()`, `tune_survdnn()`
- Introduced `survdnn_set_seed()` to sync R and torch RNG
- Ensured fold-by-fold reproducibility in CV and tuning
- Updated tests and documentation