### PR TITLE
fix: harden CRAN donttest examples and use survival::veteran

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^README_files$
 ^cran-comments\.md$
 ^README.html$
+^\.codex$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 **/*.quarto_ipynb
 README.html
+.codex

--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -98,18 +98,19 @@ evaluate_survdnn <- function(model,
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran)
-#' cv_survdnn(
-#'   Surv(time, status) ~ age + karno + celltype,
-#'   data = veteran,
-#'   times = c(30, 90, 180),
-#'   metrics = "ibs",
-#'   folds = 3,
-#'   .seed = 42,
-#'   hidden = c(16, 8),
-#'   epochs = 5
-#' )
+#' if (torch::torch_is_installed()) {
+#'   veteran <- survival::veteran
+#'   cv_survdnn(
+#'     survival::Surv(time, status) ~ age + karno + celltype,
+#'     data = veteran,
+#'     times = c(30, 90, 180),
+#'     metrics = "ibs",
+#'     folds = 3,
+#'     .seed = 42,
+#'     hidden = c(16, 8),
+#'     epochs = 5
+#'   )
+#' }
 #' }
 cv_survdnn <- function(formula, data, times,
                        metrics = c("cindex", "ibs"),
@@ -182,19 +183,20 @@ cv_survdnn <- function(formula, data, times,
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran)
-#' res <- cv_survdnn(
-#'   Surv(time, status) ~ age + karno + celltype,
-#'   data = veteran,
-#'   times = c(30, 90, 180, 270),
-#'   metrics = c("cindex", "ibs"),
-#'   folds = 3,
-#'   .seed = 42,
-#'   hidden = c(16, 8),
-#'   epochs = 5
-#' )
-#' summarize_cv_survdnn(res)
+#' if (torch::torch_is_installed()) {
+#'   veteran <- survival::veteran
+#'   res <- cv_survdnn(
+#'     survival::Surv(time, status) ~ age + karno + celltype,
+#'     data = veteran,
+#'     times = c(30, 90, 180, 270),
+#'     metrics = c("cindex", "ibs"),
+#'     folds = 3,
+#'     .seed = 42,
+#'     hidden = c(16, 8),
+#'     epochs = 5
+#'   )
+#'   summarize_cv_survdnn(res)
+#' }
 #' }
 summarize_cv_survdnn <- function(cv_results, by_time = TRUE, conf_level = 0.95) {
   stopifnot(all(c("fold", "metric", "value") %in% names(cv_results)))

--- a/R/gridsearch_survdnn.R
+++ b/R/gridsearch_survdnn.R
@@ -21,45 +21,45 @@
 #'
 #' @examples
 #' \donttest{
-#' library(survdnn)
-#' library(survival)
-#' set.seed(123)
+#' if (torch::torch_is_installed()) {
+#'   set.seed(123)
 #'
-#' # Simulate small dataset
-#' n <- 300
-#' x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
-#' time <- rexp(n, rate = 0.1)
-#' status <- rbinom(n, 1, 0.7)
-#' df <- data.frame(time, status, x1, x2)
-#' 
-#' # Split into training and validation
-#' idx <- sample(seq_len(n), 0.7 * n)
-#' train <- df[idx, ]
-#' valid <- df[-idx, ]
-#' 
-#' # Define formula and param grid
-#' formula <- Surv(time, status) ~ x1 + x2
-#' param_grid <- list(
-#'   hidden     = list(c(16, 8), c(32, 16)),
-#'   lr         = c(1e-3),
-#'   activation = c("relu"),
-#'   epochs     = c(100),
-#'   loss       = c("cox", "coxtime")
-#' )
-#' 
-#' # Run grid search
-#' results <- gridsearch_survdnn(
-#'   formula = formula,
-#'   train   = train,
-#'   valid   = valid,
-#'   times   = c(10, 20, 30),
-#'   metrics = c("cindex", "ibs"),
-#'   param_grid = param_grid
-#' )
-#' 
-#' # View summary
-#' dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
-#'   dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+#'   # Simulate small dataset
+#'   n <- 300
+#'   x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
+#'   time <- rexp(n, rate = 0.1)
+#'   status <- rbinom(n, 1, 0.7)
+#'   df <- data.frame(time, status, x1, x2)
+#'
+#'   # Split into training and validation
+#'   idx <- sample(seq_len(n), 0.7 * n)
+#'   train <- df[idx, ]
+#'   valid <- df[-idx, ]
+#'
+#'   # Define formula and param grid
+#'   formula <- survival::Surv(time, status) ~ x1 + x2
+#'   param_grid <- list(
+#'     hidden     = list(c(16, 8), c(32, 16)),
+#'     lr         = c(1e-3),
+#'     activation = c("relu"),
+#'     epochs     = c(100),
+#'     loss       = c("cox", "coxtime")
+#'   )
+#'
+#'   # Run grid search
+#'   results <- gridsearch_survdnn(
+#'     formula = formula,
+#'     train   = train,
+#'     valid   = valid,
+#'     times   = c(10, 20, 30),
+#'     metrics = c("cindex", "ibs"),
+#'     param_grid = param_grid
+#'   )
+#'
+#'   # View summary
+#'   dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
+#'     dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+#' }
 #' }
 
 gridsearch_survdnn <- function(formula, train, valid, times,
@@ -119,4 +119,3 @@ dplyr::bind_cols(config[rep(1, nrow(eval_tbl)), ], eval_tbl)
 
 return(results)
 }
-

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -14,13 +14,14 @@
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran, package = "survival")
-#' mod <- survdnn(Surv(time, status) ~
-#' age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
-#' pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
-#' y <- model.response(model.frame(mod$formula, veteran))
-#' cindex_survmat(y, pred, t_star = 180)
+#' if (torch::torch_is_installed()) {
+#'   veteran <- survival::veteran
+#'   mod <- survdnn(survival::Surv(time, status) ~
+#'   age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
+#'   pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
+#'   y <- model.response(model.frame(mod$formula, veteran))
+#'   cindex_survmat(y, pred, t_star = 180)
+#' }
 #' }
 
 cindex_survmat <- function(object, predicted, t_star = NULL) {
@@ -92,13 +93,14 @@ cindex_survmat <- function(object, predicted, t_star = NULL) {
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran, package = "survival")
-#' mod <- survdnn(Surv(time, status) ~
-#' age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
-#' pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
-#' y <- model.response(model.frame(mod$formula, veteran))
-#' survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+#' if (torch::torch_is_installed()) {
+#'   veteran <- survival::veteran
+#'   mod <- survdnn(survival::Surv(time, status) ~
+#'   age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
+#'   pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
+#'   y <- model.response(model.frame(mod$formula, veteran))
+#'   survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+#' }
 #' }
 
 brier <- function(object, pre_sp, t_star) {
@@ -155,16 +157,17 @@ brier <- function(object, pre_sp, t_star) {
 #'
 #' @examples
 #' \donttest{
-#' set.seed(123)
-#' library(survival)
-#' data(veteran, package = "survival")
-#' idx <- sample(nrow(veteran), 0.7 * nrow(veteran))
-#' train <- veteran[idx, ]; test <- veteran[-idx, ]
-#' mod <- survdnn(Surv(time, status) ~
-#' age + karno + celltype, data = train, epochs = 50, verbose = FALSE)
-#' pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
-#' y_test <- model.response(model.frame(mod$formula, test))
-#' ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+#' if (torch::torch_is_installed()) {
+#'   set.seed(123)
+#'   veteran <- survival::veteran
+#'   idx <- sample(nrow(veteran), 0.7 * nrow(veteran))
+#'   train <- veteran[idx, ]; test <- veteran[-idx, ]
+#'   mod <- survdnn(survival::Surv(time, status) ~
+#'   age + karno + celltype, data = train, epochs = 50, verbose = FALSE)
+#'   pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
+#'   y_test <- model.response(model.frame(mod$formula, test))
+#'   ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+#' }
 #' }
 
 ibs_survmat <- function(object, sp_matrix, times) {

--- a/R/plot.survdnn.R
+++ b/R/plot.survdnn.R
@@ -20,13 +20,12 @@
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran)
-#' set.seed(42)
-#' \donttest{
-#' mod <- survdnn(Surv(time, status) ~ age + karno + celltype, data = veteran,
-#'                hidden = c(16, 8), epochs = 100, verbose = FALSE)
-#' plot(mod, group_by = "celltype", times = 1:300)
+#' if (torch::torch_is_installed()) {
+#'   set.seed(42)
+#'   veteran <- survival::veteran
+#'   mod <- survdnn(survival::Surv(time, status) ~ age + karno + celltype, data = veteran,
+#'                  hidden = c(16, 8), epochs = 100, verbose = FALSE)
+#'   plot(mod, group_by = "celltype", times = 1:300)
 #' }
 #' }
 plot.survdnn <- function(x, newdata = NULL, times = 1:365,

--- a/R/print.survdnn.R
+++ b/R/print.survdnn.R
@@ -11,11 +11,12 @@
 #'
 #' @examples
 #' \donttest{
-#' library(survival)
-#' data(veteran, package = "survival")
-#' mod <- survdnn(Surv(time, status) ~
-#' age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
-#' print(mod)
+#' if (torch::torch_is_installed()) {
+#'   veteran <- survival::veteran
+#'   mod <- survdnn(survival::Surv(time, status) ~
+#'   age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
+#'   print(mod)
+#' }
 #' }
 
 print.survdnn <- function(x, ...) {

--- a/R/summary.survdnn.R
+++ b/R/summary.survdnn.R
@@ -12,16 +12,18 @@
 #'
 #' @examples
 #' \donttest{
-#' set.seed(42)
-#' sim_data <- data.frame(
-#'   age = rnorm(100, 60, 10),
-#'   sex = factor(sample(c("male", "female"), 100, TRUE)),
-#'   trt = factor(sample(c("A", "B"), 100, TRUE)),
-#'   time = rexp(100, 0.05),
-#'   status = rbinom(100, 1, 0.7)
-#' )
-#' mod <- survdnn(Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
-#' summary(mod)
+#' if (torch::torch_is_installed()) {
+#'   set.seed(42)
+#'   sim_data <- data.frame(
+#'     age = rnorm(100, 60, 10),
+#'     sex = factor(sample(c("male", "female"), 100, TRUE)),
+#'     trt = factor(sample(c("A", "B"), 100, TRUE)),
+#'     time = rexp(100, 0.05),
+#'     status = rbinom(100, 1, 0.7)
+#'   )
+#'   mod <- survdnn(survival::Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
+#'   summary(mod)
+#' }
 #' }
 
 summary.survdnn <- function(object, ...) {

--- a/man/brier.Rd
+++ b/man/brier.Rd
@@ -21,12 +21,13 @@ Computes the Brier score at a fixed time point using inverse probability of cens
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran, package = "survival")
-mod <- survdnn(Surv(time, status) ~
-age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
-pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
-y <- model.response(model.frame(mod$formula, veteran))
-survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+if (torch::torch_is_installed()) {
+  veteran <- survival::veteran
+  mod <- survdnn(survival::Surv(time, status) ~
+  age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
+  pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
+  y <- model.response(model.frame(mod$formula, veteran))
+  survdnn::brier(y, pre_sp = pred[["t=90"]], t_star = 90)
+}
 }
 }

--- a/man/cindex_survmat.Rd
+++ b/man/cindex_survmat.Rd
@@ -24,12 +24,13 @@ at a fixed time point. The risk is computed as `1 - S(t_star)`.
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran, package = "survival")
-mod <- survdnn(Surv(time, status) ~
-age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
-pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
-y <- model.response(model.frame(mod$formula, veteran))
-cindex_survmat(y, pred, t_star = 180)
+if (torch::torch_is_installed()) {
+  veteran <- survival::veteran
+  mod <- survdnn(survival::Surv(time, status) ~
+  age + karno + celltype, data = veteran, epochs = 50, verbose = FALSE)
+  pred <- predict(mod, newdata = veteran, type = "survival", times = c(30, 90, 180))
+  y <- model.response(model.frame(mod$formula, veteran))
+  cindex_survmat(y, pred, t_star = 180)
+}
 }
 }

--- a/man/cv_survdnn.Rd
+++ b/man/cv_survdnn.Rd
@@ -46,17 +46,18 @@ Performs cross-validation for a `survdnn` model using the specified evaluation m
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran)
-cv_survdnn(
-  Surv(time, status) ~ age + karno + celltype,
-  data = veteran,
-  times = c(30, 90, 180),
-  metrics = "ibs",
-  folds = 3,
-  .seed = 42,
-  hidden = c(16, 8),
-  epochs = 5
-)
+if (torch::torch_is_installed()) {
+  veteran <- survival::veteran
+  cv_survdnn(
+    survival::Surv(time, status) ~ age + karno + celltype,
+    data = veteran,
+    times = c(30, 90, 180),
+    metrics = "ibs",
+    folds = 3,
+    .seed = 42,
+    hidden = c(16, 8),
+    epochs = 5
+  )
+}
 }
 }

--- a/man/gridsearch_survdnn.Rd
+++ b/man/gridsearch_survdnn.Rd
@@ -45,44 +45,44 @@ Performs grid search over user-specified hyperparameters and evaluates performan
 }
 \examples{
 \donttest{
-library(survdnn)
-library(survival)
-set.seed(123)
+if (torch::torch_is_installed()) {
+  set.seed(123)
 
-# Simulate small dataset
-n <- 300
-x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
-time <- rexp(n, rate = 0.1)
-status <- rbinom(n, 1, 0.7)
-df <- data.frame(time, status, x1, x2)
+  # Simulate small dataset
+  n <- 300
+  x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
+  time <- rexp(n, rate = 0.1)
+  status <- rbinom(n, 1, 0.7)
+  df <- data.frame(time, status, x1, x2)
 
-# Split into training and validation
-idx <- sample(seq_len(n), 0.7 * n)
-train <- df[idx, ]
-valid <- df[-idx, ]
+  # Split into training and validation
+  idx <- sample(seq_len(n), 0.7 * n)
+  train <- df[idx, ]
+  valid <- df[-idx, ]
 
-# Define formula and param grid
-formula <- Surv(time, status) ~ x1 + x2
-param_grid <- list(
-  hidden     = list(c(16, 8), c(32, 16)),
-  lr         = c(1e-3),
-  activation = c("relu"),
-  epochs     = c(100),
-  loss       = c("cox", "coxtime")
-)
+  # Define formula and param grid
+  formula <- survival::Surv(time, status) ~ x1 + x2
+  param_grid <- list(
+    hidden     = list(c(16, 8), c(32, 16)),
+    lr         = c(1e-3),
+    activation = c("relu"),
+    epochs     = c(100),
+    loss       = c("cox", "coxtime")
+  )
 
-# Run grid search
-results <- gridsearch_survdnn(
-  formula = formula,
-  train   = train,
-  valid   = valid,
-  times   = c(10, 20, 30),
-  metrics = c("cindex", "ibs"),
-  param_grid = param_grid
-)
+  # Run grid search
+  results <- gridsearch_survdnn(
+    formula = formula,
+    train   = train,
+    valid   = valid,
+    times   = c(10, 20, 30),
+    metrics = c("cindex", "ibs"),
+    param_grid = param_grid
+  )
 
-# View summary
-dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
-  dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+  # View summary
+  dplyr::group_by(results, hidden, lr, activation, epochs, loss, metric) |>
+    dplyr::summarise(mean = mean(value, na.rm = TRUE), .groups = "drop")
+}
 }
 }

--- a/man/ibs_survmat.Rd
+++ b/man/ibs_survmat.Rd
@@ -23,15 +23,16 @@ using trapezoidal integration and IPCW adjustment for right-censoring.
 }
 \examples{
 \donttest{
-set.seed(123)
-library(survival)
-data(veteran, package = "survival")
-idx <- sample(nrow(veteran), 0.7 * nrow(veteran))
-train <- veteran[idx, ]; test <- veteran[-idx, ]
-mod <- survdnn(Surv(time, status) ~
-age + karno + celltype, data = train, epochs = 50, verbose = FALSE)
-pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
-y_test <- model.response(model.frame(mod$formula, test))
-ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+if (torch::torch_is_installed()) {
+  set.seed(123)
+  veteran <- survival::veteran
+  idx <- sample(nrow(veteran), 0.7 * nrow(veteran))
+  train <- veteran[idx, ]; test <- veteran[-idx, ]
+  mod <- survdnn(survival::Surv(time, status) ~
+  age + karno + celltype, data = train, epochs = 50, verbose = FALSE)
+  pred <- predict(mod, newdata = test, times = c(30, 90, 180), type = "survival")
+  y_test <- model.response(model.frame(mod$formula, test))
+  ibs_survmat(y_test, sp_matrix = pred, times = c(30, 90, 180))
+}
 }
 }

--- a/man/plot.survdnn.Rd
+++ b/man/plot.survdnn.Rd
@@ -48,13 +48,12 @@ optionally display only the group-wise means or overlay them.
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran)
-set.seed(42)
-\donttest{
-mod <- survdnn(Surv(time, status) ~ age + karno + celltype, data = veteran,
-               hidden = c(16, 8), epochs = 100, verbose = FALSE)
-plot(mod, group_by = "celltype", times = 1:300)
+if (torch::torch_is_installed()) {
+  set.seed(42)
+  veteran <- survival::veteran
+  mod <- survdnn(survival::Surv(time, status) ~ age + karno + celltype, data = veteran,
+                 hidden = c(16, 8), epochs = 100, verbose = FALSE)
+  plot(mod, group_by = "celltype", times = 1:300)
 }
 }
 }

--- a/man/print.survdnn.Rd
+++ b/man/print.survdnn.Rd
@@ -20,10 +20,11 @@ network architecture, training configuration, and final training loss.
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran, package = "survival")
-mod <- survdnn(Surv(time, status) ~
-age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
-print(mod)
+if (torch::torch_is_installed()) {
+  veteran <- survival::veteran
+  mod <- survdnn(survival::Surv(time, status) ~
+  age + karno + celltype, data = veteran, epochs = 20, verbose = FALSE)
+  print(mod)
+}
 }
 }

--- a/man/summarize_cv_survdnn.Rd
+++ b/man/summarize_cv_survdnn.Rd
@@ -21,18 +21,19 @@ Computes mean, standard deviation, and confidence intervals for metrics from cro
 }
 \examples{
 \donttest{
-library(survival)
-data(veteran)
-res <- cv_survdnn(
-  Surv(time, status) ~ age + karno + celltype,
-  data = veteran,
-  times = c(30, 90, 180, 270),
-  metrics = c("cindex", "ibs"),
-  folds = 3,
-  .seed = 42,
-  hidden = c(16, 8),
-  epochs = 5
-)
-summarize_cv_survdnn(res)
+if (torch::torch_is_installed()) {
+  veteran <- survival::veteran
+  res <- cv_survdnn(
+    survival::Surv(time, status) ~ age + karno + celltype,
+    data = veteran,
+    times = c(30, 90, 180, 270),
+    metrics = c("cindex", "ibs"),
+    folds = 3,
+    .seed = 42,
+    hidden = c(16, 8),
+    epochs = 5
+  )
+  summarize_cv_survdnn(res)
+}
 }
 }

--- a/man/summary.survdnn.Rd
+++ b/man/summary.survdnn.Rd
@@ -21,15 +21,17 @@ a styled header and sectioned output using \{cli\} and base formatting. The obje
 }
 \examples{
 \donttest{
-set.seed(42)
-sim_data <- data.frame(
-  age = rnorm(100, 60, 10),
-  sex = factor(sample(c("male", "female"), 100, TRUE)),
-  trt = factor(sample(c("A", "B"), 100, TRUE)),
-  time = rexp(100, 0.05),
-  status = rbinom(100, 1, 0.7)
-)
-mod <- survdnn(Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
-summary(mod)
+if (torch::torch_is_installed()) {
+  set.seed(42)
+  sim_data <- data.frame(
+    age = rnorm(100, 60, 10),
+    sex = factor(sample(c("male", "female"), 100, TRUE)),
+    trt = factor(sample(c("A", "B"), 100, TRUE)),
+    time = rexp(100, 0.05),
+    status = rbinom(100, 1, 0.7)
+  )
+  mod <- survdnn(survival::Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
+  summary(mod)
+}
 }
 }


### PR DESCRIPTION
## Summary
- guard donttest examples that train models with torch::torch_is_installed()
- switch veteran loading in examples to survival::veteran
- regenerate Rd files
- ignore local .codex artifact and .codex in build ignore

## Validation
- R CMD check --no-manual --run-donttest survdnn_0.7.5.tar.gz (Status: OK)