### PR TITLE
chore: prepare 0.7.6 CRAN resubmission release notes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: survdnn
 Title: Deep Neural Networks for Survival Analysis with R 'torch'
-Version: 0.7.5
+Version: 0.7.6
 Authors@R: 
     person(given = "Imad", 
            family = "EL BADISY", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # survdnn
 
+## survdnn 0.7.6
+
+### CRAN resubmission update
+
+* Hardened `\\donttest{}` examples that train models by guarding them with `torch::torch_is_installed()` so checks pass on systems without Torch.
+* Updated examples to load the veteran dataset explicitly via `survival::veteran` (instead of `data(veteran, ...)`).
+* Regenerated documentation (`man/*.Rd`) to reflect example updates.
+* Added `.codex` to `.gitignore` and `.Rbuildignore` to prevent local artifacts from entering source builds.
+
 ## survdnn 0.7.5
 
 ### Main changes

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,14 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-## Update 
+## Resubmission
 
-This update (version 0.7.5) fixes internal issues in loss functions (AFT and CoxTime) and prediction methods and updates documentation accordingly.
+This is a resubmission for version 0.7.6.
 
+Changes made in this update:
+
+* Guarded all model-training `\\donttest{}` examples with `torch::torch_is_installed()` so `--run-donttest` succeeds on systems without Torch installed.
+* Updated examples to use explicit dataset access via `survival::veteran`.
+* Regenerated documentation (`man/*.Rd`) after example updates.
+* Added `.codex` to `.gitignore` and `.Rbuildignore` to prevent local artifacts from being included in source builds.


### PR DESCRIPTION
## Summary
- bump package version to 0.7.6
- add NEWS entry for CRAN resubmission updates
- update cran-comments with resubmission details and check status

## Verification run
- R CMD build .
- R CMD check --no-manual --run-donttest survdnn_0.7.6.tar.gz (Status: OK)
- R CMD INSTALL survdnn_0.7.6.tar.gz (Status: OK)