### PR TITLE
chore: remove internal-tool references from notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,4 +7,4 @@
 ^README_files$
 ^cran-comments\.md$
 ^README.html$
-^\.codex$
+^\.[a-z]+$

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 
 **/*.quarto_ipynb
 README.html
-.codex

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Hardened `\\donttest{}` examples that train models by guarding them with `torch::torch_is_installed()` so checks pass on systems without Torch.
 * Updated examples to load the veteran dataset explicitly via `survival::veteran` (instead of `data(veteran, ...)`).
 * Regenerated documentation (`man/*.Rd`) to reflect example updates.
-* Added `.codex` to `.gitignore` and `.Rbuildignore` to prevent local artifacts from entering source builds.
+* Removed internal-tool references from release notes and submission notes.
 
 ## survdnn 0.7.5
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,4 +11,4 @@ Changes made in this update:
 * Guarded all model-training `\\donttest{}` examples with `torch::torch_is_installed()` so `--run-donttest` succeeds on systems without Torch installed.
 * Updated examples to use explicit dataset access via `survival::veteran`.
 * Regenerated documentation (`man/*.Rd`) after example updates.
-* Added `.codex` to `.gitignore` and `.Rbuildignore` to prevent local artifacts from being included in source builds.
+* Removed internal-tool references from package notes.


### PR DESCRIPTION
## Summary
- remove internal-tool mentions from NEWS and cran-comments
- remove explicit hidden-artifact name from tracked ignore files
- keep local hidden artifacts out of source builds via a generic Rbuildignore rule

## Verification
- R CMD build .
- R CMD check --no-manual survdnn_0.7.6.tar.gz (Status: OK)