### PR TITLE
feat: add verbose progress to cv_survdnn() and tune_survdnn()

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -45,7 +45,7 @@ evaluate_survdnn <- function(model,
   n_after <- nrow(mf)
   n_removed <- n_before - n_after
   if (n_removed > 0 && isTRUE(verbose) && na_action == "omit") {
-    message(sprintf("Removed %d observations with missing values in evaluation data.", n_removed))
+    message(sprintf("[survdnn::eval] removed %d observations with missing values in evaluation data.", n_removed))
   }
 
   y <- model.response(mf)
@@ -91,6 +91,8 @@ evaluate_survdnn <- function(model,
 #'   otherwise falls back to CPU.
 #' @param na_action Character. How to handle missing values within each fold:
 #'   `"omit"` drops incomplete rows; `"fail"` errors if any NA is present.
+#' @param verbose Logical; whether to print cross-validation progress and propagate
+#'   verbose messages to fitting/evaluation in each fold (default: TRUE).
 #' @param ... Additional arguments passed to [survdnn()].
 #'
 #' @return A tibble containing metric values per fold and (optionally) per time point.
@@ -118,6 +120,7 @@ cv_survdnn <- function(formula, data, times,
                        .seed = NULL,
                        .device = c("auto", "cpu", "cuda"),
                        na_action = c("omit", "fail"),
+                       verbose = TRUE,
                        ...) {
 
   .device   <- match.arg(.device)
@@ -133,6 +136,18 @@ cv_survdnn <- function(formula, data, times,
 
   if (!is.null(.seed)) survdnn_set_seed(.seed)
 
+  if (isTRUE(verbose)) {
+    message(
+      sprintf(
+        "[survdnn::cv] start: folds=%d n=%d metrics=%s times=%s",
+        folds,
+        nrow(data),
+        paste(metrics, collapse = ","),
+        paste(times, collapse = ",")
+      )
+    )
+  }
+
   status_var <- all.vars(formula[[2]])[2]          # more safe for extracting the status
   vfolds <- rsample::vfold_cv(data, v = folds, strata = dplyr::all_of(status_var))
 
@@ -144,9 +159,19 @@ cv_survdnn <- function(formula, data, times,
     train_data <- rsample::analysis(split)
     test_data  <- rsample::assessment(split)
 
+    if (isTRUE(verbose)) {
+      message(
+        sprintf(
+          "[survdnn::cv] fold %d/%d: train_n=%d test_n=%d",
+          i, folds, nrow(train_data), nrow(test_data)
+        )
+      )
+    }
+
     model <- survdnn(
       formula,
       data      = train_data,
+      verbose   = verbose,
       .seed     = .seed,
       .device   = .device,
       na_action = na_action,
@@ -159,12 +184,19 @@ cv_survdnn <- function(formula, data, times,
       times     = times,
       newdata   = test_data,
       na_action = na_action,
-      verbose   = FALSE
+      verbose   = verbose
     )
 
     eval_tbl$fold <- i
+    if (isTRUE(verbose)) {
+      message(sprintf("[survdnn::cv] fold %d/%d done.", i, folds))
+    }
     eval_tbl
   })
+
+  if (isTRUE(verbose)) {
+    message(sprintf("[survdnn::cv] done: completed %d folds.", folds))
+  }
 
   dplyr::select(results, fold, metric, time = dplyr::any_of("time"), value)
 }

--- a/R/survdnn.R
+++ b/R/survdnn.R
@@ -77,7 +77,7 @@ build_dnn <- function(
 #'   `"adam"`, `"adamw"`, `"sgd"`, `"rmsprop"`, or `"adagrad"`. Defaults to `"adam"`.
 #' @param optim_args Optional named list of additional arguments passed to the
 #'   underlying torch optimizer (e.g., `list(weight_decay = 1e-4, momentum = 0.9)`).
-#' @param verbose Logical; whether to print loss progress every 50 epochs (default: TRUE).
+#' @param verbose Logical; whether to print progress and periodic loss updates during fitting (default: TRUE).
 #' @param dropout Numeric between 0 and 1. Dropout rate applied after each
 #'   hidden layer (default = 0.3). Set to 0 to disable dropout.
 #' @param batch_norm Logical; whether to add batch normalization after each
@@ -173,7 +173,7 @@ survdnn <- function(
   n_after <- nrow(mf)
   n_removed <- n_before - n_after
   if (n_removed > 0 && isTRUE(verbose) && na_action == "omit") {
-    message(sprintf("Removed %d observations with missing values.", n_removed))
+    message(sprintf("[survdnn::fit] removed %d observations with missing values.", n_removed))
   }
 
   y        <- model.response(mf)
@@ -181,6 +181,15 @@ survdnn <- function(
   time     <- y[, "time"]
   status   <- y[, "status"]
   x_scaled <- scale(x)
+
+  if (isTRUE(verbose)) {
+    message(
+      sprintf(
+        "[survdnn::fit] start: n=%d p=%d loss=%s optimizer=%s epochs=%d device=%s",
+        nrow(mf), ncol(x), loss, optimizer, epochs, as.character(device)
+      )
+    )
+  }
 
   # AFT location offset for stability
   aft_loc <- NA_real_
@@ -302,8 +311,8 @@ survdnn <- function(
     loss_history[epoch] <- current_loss
     last_epoch_run      <- epoch
 
-    if (verbose && epoch %% 50 == 0) {
-      cat(sprintf("Epoch %d - Loss: %.6f\n\n", epoch, current_loss))
+    if (isTRUE(verbose) && (epoch %% 50 == 0 || epoch == epochs)) {
+      message(sprintf("[survdnn::fit] epoch %d/%d loss=%.6f", epoch, epochs, current_loss))
     }
 
     if (!is.null(callbacks)) {
@@ -319,6 +328,9 @@ survdnn <- function(
 
   if (early_stopped && last_epoch_run < epochs) {
     loss_history <- loss_history[seq_len(last_epoch_run)]
+    if (isTRUE(verbose)) {
+      message(sprintf("[survdnn::fit] early stopping at epoch %d/%d.", last_epoch_run, epochs))
+    }
   }
 
   # store learned AFT log(sigma) robustly
@@ -327,6 +339,16 @@ survdnn <- function(
     if (!is.finite(aft_log_sigma)) aft_log_sigma <- NA_real_
   } else {
     aft_log_sigma <- NA_real_
+  }
+
+  if (isTRUE(verbose)) {
+    message(
+      sprintf(
+        "[survdnn::fit] done: epochs_run=%d final_loss=%.6f",
+        last_epoch_run,
+        tail(loss_history, 1)
+      )
+    )
   }
 
   structure(

--- a/R/tune_survdnn.R
+++ b/R/tune_survdnn.R
@@ -19,6 +19,8 @@ utils::globalVariables(c("loss", "epoch"))
 #'   uses CUDA if available, otherwise falls back to CPU.
 #' @param na_action Character. How to handle missing values:
 #'   `"omit"` drops incomplete rows; `"fail"` errors if any NA is present.
+#' @param verbose Logical; whether to print tuning progress and propagate verbose
+#'   messages to nested cross-validation and optional refit (default: TRUE).
 #' @param refit Logical. If TRUE, refits the best model on the full dataset.
 #' @param return One of "all", "summary", or "best_model":
 #'   \describe{
@@ -39,6 +41,7 @@ tune_survdnn <- function(
   .seed = 42,
   .device = c("auto", "cpu", "cuda"),
   na_action = c("omit", "fail"),
+  verbose = TRUE,
   refit = FALSE,
   return = c("all", "summary", "best_model")
 ) {
@@ -49,10 +52,35 @@ tune_survdnn <- function(
   if (!is.null(.seed)) survdnn_set_seed(.seed)
 
   param_df <- tidyr::crossing(!!!param_grid)
+  n_configs <- nrow(param_df)
 
-  all_results <- purrr::pmap_dfr(
-    param_df,
-    function(hidden, lr, activation, epochs, loss) {
+  if (isTRUE(verbose)) {
+    message(
+      sprintf(
+        "[survdnn::tune] start: configs=%d folds=%d total_fits=%d",
+        n_configs, folds, n_configs * folds
+      )
+    )
+  }
+
+  all_results <- purrr::map_dfr(
+    seq_len(n_configs),
+    function(config_id) {
+      hidden <- param_df$hidden[[config_id]]
+      lr <- param_df$lr[[config_id]]
+      activation <- param_df$activation[[config_id]]
+      epochs <- param_df$epochs[[config_id]]
+      loss <- param_df$loss[[config_id]]
+
+      if (isTRUE(verbose)) {
+        message(
+          sprintf(
+            "[survdnn::tune] config %d/%d: loss=%s activation=%s hidden=%s lr=%s epochs=%d",
+            config_id, n_configs, loss, activation, toString(hidden), format(lr), epochs
+          )
+        )
+      }
+
       config_tbl <- tibble::tibble(
         hidden     = list(hidden),
         lr         = lr,
@@ -74,7 +102,8 @@ tune_survdnn <- function(
         loss       = loss,
         .seed      = .seed,
         .device    = .device,
-        na_action  = na_action
+        na_action  = na_action,
+        verbose    = verbose
       )
 
       dplyr::bind_cols(config_tbl[rep(1, nrow(cv_tbl)), ], cv_tbl)
@@ -99,9 +128,24 @@ tune_survdnn <- function(
     stop("No valid configuration found for primary metric: ", primary_metric, call. = FALSE)
   }
 
+  if (isTRUE(verbose)) {
+    message(
+      sprintf(
+        "[survdnn::tune] best config: loss=%s activation=%s hidden=%s lr=%s epochs=%d",
+        best_row_all$loss[[1]],
+        best_row_all$activation[[1]],
+        toString(best_row_all$hidden[[1]]),
+        format(best_row_all$lr[[1]]),
+        best_row_all$epochs[[1]]
+      )
+    )
+  }
+
   ## refitting the best model
   if (refit) {
-    message("Refitting best model on full data...")
+    if (isTRUE(verbose)) {
+      message("[survdnn::tune] refitting best model on full data...")
+    }
     best_model <- survdnn(
       formula    = formula,
       data       = data,
@@ -112,8 +156,13 @@ tune_survdnn <- function(
       loss       = best_row_all$loss[[1]],
       .seed      = .seed,
       .device    = .device,
+      verbose    = verbose,
       na_action  = na_action
     )
+  }
+
+  if (isTRUE(verbose)) {
+    message("[survdnn::tune] done.")
   }
 
   switch(

--- a/man/cv_survdnn.Rd
+++ b/man/cv_survdnn.Rd
@@ -13,6 +13,7 @@ cv_survdnn(
   .seed = NULL,
   .device = c("auto", "cpu", "cuda"),
   na_action = c("omit", "fail"),
+  verbose = TRUE,
   ...
 )
 }
@@ -35,6 +36,9 @@ otherwise falls back to CPU.}
 
 \item{na_action}{Character. How to handle missing values within each fold:
 `"omit"` drops incomplete rows; `"fail"` errors if any NA is present.}
+
+\item{verbose}{Logical; whether to print cross-validation progress and propagate
+verbose messages to fitting/evaluation in each fold (default: TRUE).}
 
 \item{...}{Additional arguments passed to [survdnn()].}
 }

--- a/man/survdnn.Rd
+++ b/man/survdnn.Rd
@@ -45,7 +45,7 @@ Supported options: `"relu"`, `"leaky_relu"`, `"tanh"`, `"sigmoid"`, `"gelu"`, `"
 \item{optim_args}{Optional named list of additional arguments passed to the
 underlying torch optimizer (e.g., `list(weight_decay = 1e-4, momentum = 0.9)`).}
 
-\item{verbose}{Logical; whether to print loss progress every 50 epochs (default: TRUE).}
+\item{verbose}{Logical; whether to print progress and periodic loss updates during fitting (default: TRUE).}
 
 \item{dropout}{Numeric between 0 and 1. Dropout rate applied after each
 hidden layer (default = 0.3). Set to 0 to disable dropout.}

--- a/man/tune_survdnn.Rd
+++ b/man/tune_survdnn.Rd
@@ -14,6 +14,7 @@ tune_survdnn(
   .seed = 42,
   .device = c("auto", "cpu", "cuda"),
   na_action = c("omit", "fail"),
+  verbose = TRUE,
   refit = FALSE,
   return = c("all", "summary", "best_model")
 )
@@ -41,6 +42,9 @@ uses CUDA if available, otherwise falls back to CPU.}
 
 \item{na_action}{Character. How to handle missing values:
 `"omit"` drops incomplete rows; `"fail"` errors if any NA is present.}
+
+\item{verbose}{Logical; whether to print tuning progress and propagate verbose
+messages to nested cross-validation and optional refit (default: TRUE).}
 
 \item{refit}{Logical. If TRUE, refits the best model on the full dataset.}
 

--- a/tests/testthat/test-cv_survdnn.R
+++ b/tests/testthat/test-cv_survdnn.R
@@ -42,3 +42,45 @@ test_that("cv_survdnn errors on missing inputs or bad arguments", {
     "must provide a `times`"
   )
 })
+
+test_that("cv_survdnn verbose controls progress messages", {
+  skip_on_cran()
+  skip_if_not(torch::torch_is_installed())
+
+  data <- survival::veteran
+
+  msg_on <- capture.output(
+    cv_survdnn(
+      Surv(time, status) ~ age + karno + celltype,
+      data = data,
+      times = c(30),
+      metrics = c("ibs"),
+      folds = 2,
+      .seed = 123,
+      hidden = c(8),
+      epochs = 1,
+      verbose = TRUE
+    ),
+    type = "message"
+  )
+
+  expect_true(any(grepl("\\[survdnn::cv\\]", msg_on)))
+  expect_true(any(grepl("\\[survdnn::fit\\]", msg_on)))
+
+  msg_off <- capture.output(
+    cv_survdnn(
+      Surv(time, status) ~ age + karno + celltype,
+      data = data,
+      times = c(30),
+      metrics = c("ibs"),
+      folds = 2,
+      .seed = 123,
+      hidden = c(8),
+      epochs = 1,
+      verbose = FALSE
+    ),
+    type = "message"
+  )
+
+  expect_false(any(grepl("\\[survdnn::cv\\]|\\[survdnn::fit\\]|\\[survdnn::eval\\]", msg_off)))
+})

--- a/tests/testthat/test-tune_survdnn.R
+++ b/tests/testthat/test-tune_survdnn.R
@@ -20,6 +20,7 @@ test_that("tune_survdnn returns correct structure for all modes", {
     param_grid = param_grid,
     folds = 2,
     .seed = 123,
+    verbose = FALSE,
     refit = FALSE,
     return = "all"
   )
@@ -35,6 +36,7 @@ test_that("tune_survdnn returns correct structure for all modes", {
     param_grid = param_grid,
     folds = 2,
     .seed = 123,
+    verbose = FALSE,
     refit = FALSE,
     return = "summary"
   )
@@ -50,6 +52,7 @@ test_that("tune_survdnn returns correct structure for all modes", {
     param_grid = param_grid,
     folds = 2,
     .seed = 123,
+    verbose = FALSE,
     refit = FALSE,
     return = "best_model"
   )
@@ -80,6 +83,7 @@ test_that("tune_survdnn works with refit = TRUE and returns survdnn model", {
     param_grid = param_grid,
     folds = 2,
     .seed = 42,
+    verbose = FALSE,
     refit = TRUE,
     return = "best_model"
   )
@@ -110,6 +114,7 @@ test_that("summarize_tune_survdnn aggregates correctly and throws on bad input",
     param_grid = param_grid,
     folds = 2,
     .seed = 123,
+    verbose = FALSE,
     refit = FALSE,
     return = "all"
   )
@@ -122,4 +127,55 @@ test_that("summarize_tune_survdnn aggregates correctly and throws on bad input",
   }
 
   expect_error(summarize_tune_survdnn(data.frame(a = 1)), "Input must be the result")
+})
+
+test_that("tune_survdnn verbose controls progress messages", {
+  skip_on_cran()
+  skip_if_not(torch::torch_is_installed())
+
+  data <- survival::veteran
+  param_grid <- list(
+    hidden     = list(c(8)),
+    lr         = c(1e-3),
+    activation = c("relu"),
+    epochs     = c(1),
+    loss       = c("cox")
+  )
+
+  msg_on <- capture.output(
+    tune_survdnn(
+      Surv(time, status) ~ age + karno + celltype,
+      data = data,
+      times = c(30),
+      metrics = "cindex",
+      param_grid = param_grid,
+      folds = 2,
+      .seed = 123,
+      verbose = TRUE,
+      refit = FALSE,
+      return = "summary"
+    ),
+    type = "message"
+  )
+
+  expect_true(any(grepl("\\[survdnn::tune\\]", msg_on)))
+  expect_true(any(grepl("\\[survdnn::cv\\]", msg_on)))
+
+  msg_off <- capture.output(
+    tune_survdnn(
+      Surv(time, status) ~ age + karno + celltype,
+      data = data,
+      times = c(30),
+      metrics = "cindex",
+      param_grid = param_grid,
+      folds = 2,
+      .seed = 123,
+      verbose = FALSE,
+      refit = FALSE,
+      return = "summary"
+    ),
+    type = "message"
+  )
+
+  expect_false(any(grepl("\\[survdnn::tune\\]|\\[survdnn::cv\\]|\\[survdnn::fit\\]", msg_off)))
 })


### PR DESCRIPTION
## Summary
- add explicit  argument to  and 
- propagate verbosity to nested fit/eval/refit calls
- improve progress messages across fit/cv/tune with consistent prefixes
- add tests to verify verbose message behavior
- regenerate Rd documentation

## Validation
- Rscript -e 'roxygen2::roxygenise()'
- R CMD build .
- R CMD check --no-manual survdnn_0.7.6.tar.gz (Status: OK)

Closes #25