### PR TITLE
docs: update 0.7.6 notes for verbose cv/tune fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 * Hardened `\\donttest{}` examples that train models by guarding them with `torch::torch_is_installed()` so checks pass on systems without Torch.
 * Updated examples to load the veteran dataset explicitly via `survival::veteran` (instead of `data(veteran, ...)`).
+* Added explicit `verbose` support to `cv_survdnn()` and `tune_survdnn()`, with clearer and consistent progress messages across fit/cv/tune workflows.
 * Regenerated documentation (`man/*.Rd`) to reflect example updates.
 * Removed internal-tool references from release notes and submission notes.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -10,5 +10,6 @@ Changes made in this update:
 
 * Guarded all model-training `\\donttest{}` examples with `torch::torch_is_installed()` so `--run-donttest` succeeds on systems without Torch installed.
 * Updated examples to use explicit dataset access via `survival::veteran`.
+* Added explicit `verbose` arguments to `cv_survdnn()` and `tune_survdnn()`, and improved consistency of progress messages across fit/cv/tune.
 * Regenerated documentation (`man/*.Rd`) after example updates.
 * Removed internal-tool references from package notes.


### PR DESCRIPTION
## Summary
- update NEWS.md for 0.7.6 to mention explicit verbose support in cv_survdnn()/tune_survdnn()
- update cran-comments.md resubmission bullets with the same fix

## Validation
- R CMD build .
- R CMD check --no-manual survdnn_0.7.6.tar.gz (Status: OK)