### PR TITLE
Reduce CRAN example check notes

### DIFF
--- a/R/gridsearch_survdnn.R
+++ b/R/gridsearch_survdnn.R
@@ -25,7 +25,7 @@
 #'   set.seed(123)
 #'
 #'   # Simulate small dataset
-#'   n <- 300
+#'   n <- 60
 #'   x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
 #'   time <- rexp(n, rate = 0.1)
 #'   status <- rbinom(n, 1, 0.7)
@@ -39,11 +39,11 @@
 #'   # Define formula and param grid
 #'   formula <- survival::Surv(time, status) ~ x1 + x2
 #'   param_grid <- list(
-#'     hidden     = list(c(16, 8), c(32, 16)),
+#'     hidden     = list(c(4)),
 #'     lr         = c(1e-3),
 #'     activation = c("relu"),
-#'     epochs     = c(100),
-#'     loss       = c("cox", "coxtime")
+#'     epochs     = c(1),
+#'     loss       = c("cox")
 #'   )
 #'
 #'   # Run grid search
@@ -51,7 +51,7 @@
 #'     formula = formula,
 #'     train   = train,
 #'     valid   = valid,
-#'     times   = c(10, 20, 30),
+#'     times   = c(10, 20),
 #'     metrics = c("cindex", "ibs"),
 #'     param_grid = param_grid
 #'   )

--- a/R/summary.survdnn.R
+++ b/R/summary.survdnn.R
@@ -21,7 +21,12 @@
 #'     time = rexp(100, 0.05),
 #'     status = rbinom(100, 1, 0.7)
 #'   )
-#'   mod <- survdnn(survival::Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
+#'   mod <- survdnn(
+#'     survival::Surv(time, status) ~ age + sex + trt,
+#'     data = sim_data,
+#'     epochs = 50,
+#'     verbose = FALSE
+#'   )
 #'   summary(mod)
 #' }
 #' }

--- a/man/gridsearch_survdnn.Rd
+++ b/man/gridsearch_survdnn.Rd
@@ -49,7 +49,7 @@ if (requireNamespace("torch", quietly = TRUE) && torch::torch_is_installed()) {
   set.seed(123)
 
   # Simulate small dataset
-  n <- 300
+  n <- 60
   x1 <- rnorm(n); x2 <- rbinom(n, 1, 0.5)
   time <- rexp(n, rate = 0.1)
   status <- rbinom(n, 1, 0.7)
@@ -63,11 +63,11 @@ if (requireNamespace("torch", quietly = TRUE) && torch::torch_is_installed()) {
   # Define formula and param grid
   formula <- survival::Surv(time, status) ~ x1 + x2
   param_grid <- list(
-    hidden     = list(c(16, 8), c(32, 16)),
+    hidden     = list(c(4)),
     lr         = c(1e-3),
     activation = c("relu"),
-    epochs     = c(100),
-    loss       = c("cox", "coxtime")
+    epochs     = c(1),
+    loss       = c("cox")
   )
 
   # Run grid search
@@ -75,7 +75,7 @@ if (requireNamespace("torch", quietly = TRUE) && torch::torch_is_installed()) {
     formula = formula,
     train   = train,
     valid   = valid,
-    times   = c(10, 20, 30),
+    times   = c(10, 20),
     metrics = c("cindex", "ibs"),
     param_grid = param_grid
   )

--- a/man/summary.survdnn.Rd
+++ b/man/summary.survdnn.Rd
@@ -30,7 +30,12 @@ if (requireNamespace("torch", quietly = TRUE) && torch::torch_is_installed()) {
     time = rexp(100, 0.05),
     status = rbinom(100, 1, 0.7)
   )
-  mod <- survdnn(survival::Surv(time, status) ~ age + sex + trt, data = sim_data, epochs = 50, verbose = FALSE)
+  mod <- survdnn(
+    survival::Surv(time, status) ~ age + sex + trt,
+    data = sim_data,
+    epochs = 50,
+    verbose = FALSE
+  )
   summary(mod)
 }
 }


### PR DESCRIPTION
## Summary
- reduce the gridsearch_survdnn example to a tiny illustrative fit
- wrap the summary.survdnn example line to satisfy Rd line-width checks
- confirmed veteran examples use survival::veteran, not data(veteran)

## Verification
- R CMD build .
- R CMD check --as-cran --run-donttest survdnn_0.7.6.tar.gz

Result: examples and tests OK; only NOTE is local timestamp verification: unable to verify current time.